### PR TITLE
feat(analytics): do not deactivate the add-on if the PHP or Give Core minimum version does not match #3440

### DIFF
--- a/give-google-analytics.php
+++ b/give-google-analytics.php
@@ -40,7 +40,7 @@ if ( ! defined( 'GIVE_GOOGLE_ANALYTICS_URL' ) ) {
 
 // Basename.
 if ( ! defined( 'GIVE_GOOGLE_ANALYTICS_BASENAME' ) ) {
-	define( 'GIVE_GOOGLE_ANALYTICS_BASENAME', plugin_basename( GIVE_GOOGLE_ANALYTICS_DIR ) );
+	define( 'GIVE_GOOGLE_ANALYTICS_BASENAME', plugin_basename( GIVE_GOOGLE_ANALYTICS_PLUGIN_FILE ) );
 }
 
 /**

--- a/includes/give-google-analytics-activation.php
+++ b/includes/give-google-analytics-activation.php
@@ -14,47 +14,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Give Google Analytics Ecommerce Tracking Activation Banner
- *
- * Includes and initializes Give activation banner class.
- *
- * @since 1.0
- */
-function give_google_analytics_activation_banner() {
-
-	// Check for activation banner inclusion.
-	if ( ! class_exists( 'Give_Addon_Activation_Banner' )
-		 && file_exists( GIVE_PLUGIN_DIR . 'includes/admin/class-addon-activation-banner.php' )
-	) {
-
-		include GIVE_PLUGIN_DIR . 'includes/admin/class-addon-activation-banner.php';
-	}
-
-	// Initialize activation welcome banner.
-	if ( class_exists( 'Give_Addon_Activation_Banner' ) ) {
-
-		// Only runs on admin
-		$args = array(
-			'file'              => __FILE__,
-			'name'              => esc_html__( 'Google Analytics', 'give-google-analytics' ),
-			'version'           => GIVE_GOOGLE_ANALYTICS_VERSION,
-			'settings_url'      => admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=general&section=google-analytics' ),
-			'documentation_url' => 'https://givewp.com/documentation/add-ons/google-analytics/',
-			'support_url'       => 'https://givewp.com/support/',
-			'testing'           => false, // Never leave as TRUE!
-		);
-
-		new Give_Addon_Activation_Banner( $args );
-
-	}
-	return false;
-
-}
-
-add_action( 'admin_init', 'give_google_analytics_activation_banner' );
-
-
-/**
  * Plugins row action links
  *
  * @since 1.0


### PR DESCRIPTION
## Description
PR to fix issue https://github.com/WordImpress/Give/issues/3440 in https://github.com/WordImpress/Give-Google-Analytics/

## How Has This Been Tested?
Tested by activating the Add-on when Give Plugin is not activate 
Tested by activating the Add-on when Give Plugin is activated and version is less then what is required 
Tested by activating the Add-on when Give Plugin is activated and updated to the latest version 

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.